### PR TITLE
fix postmap exec to update *.db files if source is newer or missing

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -73,11 +73,11 @@ define postfix::map (
 
   if $ext != 'unknown' {
     exec { "rebuild map ${title}":
-      command     => "${postmap_command} ${type}:${filename}",
-      subscribe   => Concat[$filename],
-      refreshonly => true,
-      creates     => "${filename}.${ext}",
-      notify      => Service['postfix'],
+      command => "${postmap_command} ${type}:${filename}",
+      require => Concat[$filename],
+      unless  => "test ${filename}.${ext} -nt ${filename}",
+      path    => '/bin:/usr/bin:/sbin:/usr/sbin',
+      notify  => Service['postfix'],
     }
   }
 }

--- a/spec/defines/map_spec.rb
+++ b/spec/defines/map_spec.rb
@@ -28,11 +28,10 @@ describe 'postfix::map' do
     context 'rebuild map' do
       it {
         is_expected.to contain_exec('rebuild map ' + title)
-          .with_refreshonly(true)
           .with_command(%r{postmap})
-          .with_subscribe('Concat[/etc/postfix/maps/' + title + ']')
+          .with_require('Concat[/etc/postfix/maps/' + title + ']')
           .with_notify('Service[postfix]')
-          .with_creates('/etc/postfix/maps/' + title + '.db')
+          .with_unless(%r{/etc/postfix/maps/#{title}.db})
       }
     end
   end
@@ -113,10 +112,10 @@ describe 'postfix::map' do
         context 'rebuild map' do
           it {
             is_expected.to contain_exec('rebuild map custom_map_path_and_name')
-              .with_refreshonly(true)
               .with_command('/usr/sbin/postmap hash:/blah/fasel/myname')
-              .with_subscribe('Concat[/blah/fasel/myname]')
+              .with_require('Concat[/blah/fasel/myname]')
               .with_notify('Service[postfix]')
+              .with_unless(%r{/blah/fasel/myname.(db|cdb|pag)})
           }
         end
       end
@@ -142,10 +141,10 @@ describe 'postfix::map' do
         context 'rebuild map' do
           it {
             is_expected.to contain_exec('rebuild map custom_map_path')
-              .with_refreshonly(true)
               .with_command('/usr/sbin/postmap hash:/blah/fasel/custom_map_path')
-              .with_subscribe('Concat[/blah/fasel/custom_map_path]')
+              .with_require('Concat[/blah/fasel/custom_map_path]')
               .with_notify('Service[postfix]')
+              .with_unless(%r{/blah/fasel/#{title}.db})
           }
         end
       end
@@ -162,10 +161,10 @@ describe 'postfix::map' do
         context 'rebuild map' do
           it {
             is_expected.to contain_exec('rebuild map custom_postmap')
-              .with_refreshonly(true)
               .with_command('my_postmap_command hash:/etc/postfix/maps/custom_postmap')
-              .with_subscribe('Concat[/etc/postfix/maps/custom_postmap]')
+              .with_require('Concat[/etc/postfix/maps/custom_postmap]')
               .with_notify('Service[postfix]')
+              .with_unless(%r{/etc/postfix/maps/#{title}.db})
           }
         end
       end


### PR DESCRIPTION
The exec parameter `creates` inhibits the exec from running after the nominated file is has been created, even when the exec is being 'notified'.

https://puppet.com/docs/puppet/6.4/type.html#exec

>    If the exec would not have run (due to an `onlyif`, `unless`, or `creates` attribute) and receives an event, it still will not run.

This `unless` clause will run the exec whenever:
* the db file is older than the text file
* the db file is missing