### PR TITLE
Update service.pp

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -54,6 +54,11 @@ class postfix::service(
   }
 
   if $sync_chroot != '' {
+    file  { "${sync_chroot}/etc":
+      ensure => 'directory',
+      notify => Service['postfix'],
+      tag    => 'postfix-require-packages',
+    }
     file  { "${sync_chroot}/etc/resolv.conf":
       source => '/etc/resolv.conf',
       notify => Service['postfix'],


### PR DESCRIPTION
ensure etc/ in chroot as it's not created automatically on RHEL 9 from the postfix package

I know Redhat is not officially supported by the module, but we needed a simple postfix nullmailer config as Redhat 8+ dropped ssmtp and as we used your module for postfix on Debian anyway, we just gave it a try and it seems to work fine despite /var/spool/postfix/etc is missing in a chrooted setup which seems to be the Redhat default.

As the change shouldn't break anything on Debian where /var/spool/postfix/etc is created from the postfix package I thought I might ask kindly if your're willing to include the small change anyways. If you prefer not to it's no big trouble for us as we created it with a profile class now - but messing with dependencies which need to sneak into a modules internal setup process always feels a bit flaky ...

Best regards from Hamburg!