### PR TITLE
add sane defaults for postfix::map alias

### DIFF
--- a/manifests/map.pp
+++ b/manifests/map.pp
@@ -27,11 +27,11 @@
 #   file mode of the map file
 #
 define postfix::map (
-  String              $map_dir,
-  String              $postmap_command,
-  String              $owner,
-  String              $group,
-  String              $mode,
+  String              $map_dir         = $postfix::map_dir,
+  String              $postmap_command = $postfix::postmap_command,
+  String              $owner           = $postfix::owner,
+  String              $group           = $postfix::group,
+  String              $mode            = $postfix::mode,
   String              $map_name        = $title,
   String              $type            = 'hash',
   Optional[String[1]] $source          = undef,


### PR DESCRIPTION
We keep using this structure whenever we define a map:

```puppet
    postfix::map { 'sender_relay':
      map_dir         => $postfix::map_dir,
      postmap_command => $postfix::postmap_command,
      owner           => $postfix::owner,
      group           => $postfix::group,
      mode            => $postfix::mode,
      contents        => [
        'anarcat@example.org               [submission.torproject.org]:submission',
      ],
```

This is silly, no? Seems to me all this could be condensed to:

```puppet
    postfix::map { 'sender_relay':
      contents        => [
        'anarcat@example.org               [submission.torproject.org]:submission',
      ],
```

... with those defaults.